### PR TITLE
fix generation batching and single process accelerator bugs

### DIFF
--- a/eval_llada.py
+++ b/eval_llada.py
@@ -274,7 +274,8 @@ class LLaDAEvalHarness(LM):
             generated_answer = self.tokenizer.decode(generated_answer_ids, skip_special_tokens=True)
             out.append(generated_answer)
 
-            self.accelerator.wait_for_everyone()
+            if self.accelerator is not None:
+                self.accelerator.wait_for_everyone()
 
         return out
 

--- a/generate.py
+++ b/generate.py
@@ -55,7 +55,7 @@ def generate(model, prompt, steps=128, gen_length=128, block_length=128, tempera
         remasking: Remasking strategy. 'low_confidence' or 'random'.
         mask_id: The toke id of [MASK] is 126336.
     '''
-    x = torch.full((1, prompt.shape[1] + gen_length), mask_id, dtype=torch.long).to(model.device)
+    x = torch.full((prompt.shape[0], prompt.shape[1] + gen_length), mask_id, dtype=torch.long).to(model.device)
     x[:, :prompt.shape[1]] = prompt.clone()
 
     prompt_index = (x != mask_id)


### PR DESCRIPTION
This PR fixes two things:
- In `generate.py`, the state tensor `x` containing the prompt as well as the masked and unmasked tokens had a hardcoded batch size of 1, meaning that the user cannot perform batching. Fix: set first dim of `x` to `prompt.shape[0]` during initialization
- In `eval_llada.py`, if the # of processes is 1 (for ex. in single GPU case), then `self.accelerator` is set to `None`. In this scenario, performing `self.accelerator.wait_for_everyone` will cause an error. Fix: add a check for if the variable is `None`
